### PR TITLE
Upgrade to the latest version Confluence 6.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /installer \
     && chmod 777 /installer \
     && cd /installer
 
-ADD "https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-6.1.2-x64.bin" /installer/
+ADD "https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-6.8.1-x64.bin" /installer/
 
 COPY ./response.varfile /installer/
 COPY ./setenv.sh /installer/
@@ -12,7 +12,7 @@ COPY ./setenv.sh /installer/
 RUN chmod -R 777 /installer/ \
     && cd /installer \
     && ls -la \
-    && ./atlassian-confluence-6.1.2-x64.bin -q -varfile response.varfile \
+    && ./atlassian-confluence-6.8.1-x64.bin -q -varfile response.varfile \
     && rm -f /var/atlassian/application-data/lock \
     && mv -f /installer/setenv.sh /opt/atlassian/confluence/bin/ \
     && rm -rf /installer \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-Created by Pawel Rozek on April 3, 2018
+Created by Pawel Rozek on April 4, 2018
 
-Atlassian Confluence 6.1.2
+Atlassian Confluence 6.8.1
+
+Based on latest CentOS
 
 Home Directory can be mapped as /var/atlassian/application-data/
 
@@ -15,6 +17,6 @@ Pre-Requesits:
       - /opt/atlassian
       - /opt/conflogs
 1. Clone files to Directory on your local machine
-2. Build image: docker build -t "confluence:6.1.2" ./
+2. Build image: docker build -t "confluence:6.8.1" ./
 3. Run docker-compose up -d
 4. Go to http://localhost:8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 confluence:
-  image: confluence:6.1.2
+  image: confluence:6.8.1
   container_name: confluence
   restart: always
   volumes:

--- a/response.varfile
+++ b/response.varfile
@@ -1,5 +1,5 @@
-#install4j response file for Confluence 6.1.2
-#Tue Apr 3 09:30:00 EDT 2018
+#install4j response file for Confluence 6.8.1
+#Tue Apr 4 12:45:40 EDT 2018
 #Created by Pawel Rozek
 executeLauncherAction$Boolean=true
 app.install.service$Boolean=true


### PR DESCRIPTION
Upgraded to latest version of Confluence 6.8.1 available for download from Atlassian website on April 4, 2018